### PR TITLE
correct subdomain parsing

### DIFF
--- a/hsts.go
+++ b/hsts.go
@@ -61,7 +61,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func parseHeader(h string) (subdomains bool, maxAge int64) {
-	subdomains = strings.Contains(h, "includeSubdomains")
+	subdomains = strings.Contains(h, "includeSubDomains")
 	maxAge = 10
 
 	for _, v := range strings.Split(h, ";") {

--- a/storage.go
+++ b/storage.go
@@ -30,7 +30,7 @@ func (hs *MemStorage) Contains(h string) bool {
 	}
 
 	// is h a subdomain of an hsts domain, walk the domain to see if it is a sub
-	// sub ... sub domain of a domain that has the `includeSubdomains` rule
+	// sub ... sub domain of a domain that has the `includeSubDomains` rule
 	l := len(h)
 	originalHost := h
 	for l > 0 {


### PR DESCRIPTION
and also fix the error in the storage tests caused by calling `t.Fatalf` from non-main goroutine.

Fixes Issue #1 and Issue #2 
